### PR TITLE
add 2nd_stage_v0_0_1 model

### DIFF
--- a/models/2nd_stage_v0_0_1/annotations/label_map.pbtxt
+++ b/models/2nd_stage_v0_0_1/annotations/label_map.pbtxt
@@ -1,0 +1,20 @@
+item { 
+	name:'cpf_column'
+	id:1
+}
+item { 
+	name:'question_line'
+	id:2
+}
+item { 
+	name:'selected_ball'
+	id:3
+}
+item { 
+	name:'unselected_ball'
+	id:4
+}
+item { 
+	name:'question_number'
+	id:5
+}

--- a/models/2nd_stage_v0_0_1/pipeline.config
+++ b/models/2nd_stage_v0_0_1/pipeline.config
@@ -1,0 +1,199 @@
+model {
+  ssd {
+    num_classes: 5
+    image_resizer {
+      fixed_shape_resizer {
+        height: 320
+        width: 320
+      }
+    }
+    feature_extractor {
+      type: "ssd_mobilenet_v2_fpn_keras"
+      depth_multiplier: 1.0
+      min_depth: 16
+      conv_hyperparams {
+        regularizer {
+          l2_regularizer {
+            weight: 4e-05
+          }
+        }
+        initializer {
+          random_normal_initializer {
+            mean: 0.0
+            stddev: 0.01
+          }
+        }
+        activation: RELU_6
+        batch_norm {
+          decay: 0.997
+          scale: true
+          epsilon: 0.001
+        }
+      }
+      use_depthwise: true
+      override_base_feature_extractor_hyperparams: true
+      fpn {
+        min_level: 3
+        max_level: 7
+        additional_layer_depth: 128
+      }
+    }
+    box_coder {
+      faster_rcnn_box_coder {
+        y_scale: 10.0
+        x_scale: 10.0
+        height_scale: 5.0
+        width_scale: 5.0
+      }
+    }
+    matcher {
+      argmax_matcher {
+        matched_threshold: 0.5
+        unmatched_threshold: 0.5
+        ignore_thresholds: false
+        negatives_lower_than_unmatched: true
+        force_match_for_each_row: true
+        use_matmul_gather: true
+      }
+    }
+    similarity_calculator {
+      iou_similarity {
+      }
+    }
+    box_predictor {
+      weight_shared_convolutional_box_predictor {
+        conv_hyperparams {
+          regularizer {
+            l2_regularizer {
+              weight: 4e-05
+            }
+          }
+          initializer {
+            random_normal_initializer {
+              mean: 0.0
+              stddev: 0.01
+            }
+          }
+          activation: RELU_6
+          batch_norm {
+            decay: 0.997
+            scale: true
+            epsilon: 0.001
+          }
+        }
+        depth: 128
+        num_layers_before_predictor: 4
+        kernel_size: 3
+        class_prediction_bias_init: -4.6
+        share_prediction_tower: true
+        use_depthwise: true
+      }
+    }
+    anchor_generator {
+      multiscale_anchor_generator {
+        min_level: 3
+        max_level: 7
+        anchor_scale: 4.0
+        aspect_ratios: 1.0
+        aspect_ratios: 2.0
+        aspect_ratios: 0.5
+        aspect_ratios: 8.0
+        aspect_ratios: 0.125
+        scales_per_octave: 2
+      }
+    }
+    post_processing {
+      batch_non_max_suppression {
+        score_threshold: 0.1
+        iou_threshold: 0.25
+        max_detections_per_class: 100
+        max_total_detections: 100
+        use_static_shapes: false
+      }
+      score_converter: SIGMOID
+    }
+    normalize_loss_by_num_matches: true
+    loss {
+      localization_loss {
+        weighted_smooth_l1 {
+        }
+      }
+      classification_loss {
+        weighted_sigmoid_focal {
+          gamma: 2.0
+          alpha: 0.25
+        }
+      }
+      classification_weight: 1.0
+      localization_weight: 1.0
+    }
+    encode_background_as_zeros: true
+    normalize_loc_loss_by_codesize: true
+    inplace_batchnorm_update: true
+    freeze_batchnorm: false
+  }
+}
+train_config {
+  batch_size: 4
+  data_augmentation_options {
+    random_patch_gaussian {
+    }
+  }
+  data_augmentation_options {
+    random_adjust_hue {
+    }
+  }
+  data_augmentation_options {
+    random_rgb_to_gray {
+    }
+  }
+  data_augmentation_options {
+    random_jpeg_quality {
+    }
+  }
+  data_augmentation_options {
+    random_distort_color {
+    }
+  }
+  sync_replicas: true
+  optimizer {
+    momentum_optimizer {
+      learning_rate {
+        cosine_decay_learning_rate {
+          learning_rate_base: 0.01
+          total_steps: 35000
+          warmup_learning_rate: 0.0
+          warmup_steps: 4000
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  fine_tune_checkpoint: "/workspace/models/object_detection/mobilenet_ssd_EF/ckpt-0"
+  num_steps: 35000
+  startup_delay_steps: 0.0
+  replicas_to_aggregate: 8
+  max_number_of_boxes: 100
+  unpad_groundtruth_tensors: false
+  fine_tune_checkpoint_type: "detection"
+  fine_tune_checkpoint_version: V2
+}
+train_input_reader {
+  label_map_path: "/workspace/models/object_detection/RS3-2nd_stage_v0_0_0_7_20230609114018/annotations/label_map.pbtxt"
+  tf_record_input_reader {
+    input_path: "/workspace/models/object_detection/RS3-2nd_stage_v0_0_0_7_20230609114018/annotations/training.record"
+  }
+}
+eval_config {
+  metrics_set: "coco_detection_metrics"
+  use_moving_averages: false
+}
+eval_input_reader {
+  label_map_path: "/workspace/models/object_detection/RS3-2nd_stage_v0_0_0_7_20230609114018/annotations/label_map.pbtxt"
+  shuffle: false
+  num_epochs: 1
+  tf_record_input_reader {
+    input_path: "/workspace/models/object_detection/RS3-2nd_stage_v0_0_0_7_20230609114018/annotations/validation.record"
+  }
+}

--- a/src/exam_scanner.py
+++ b/src/exam_scanner.py
@@ -169,7 +169,13 @@ def main():
         "--label_map_2nd_stage",
         type=str,
         nargs="+",
-        default=["cpf_column", "question_line", "selected_ball", "question_number"],
+        default=[
+            "cpf_column",
+            "question_line",
+            "selected_ball",
+            "unselected_ball",
+            "question_number",
+        ],
     )
     parser.add_argument("--score_threshold_1st_stage", type=float, default=0.5)
     parser.add_argument("--score_threshold_2nd_stage", type=float, default=0.5)


### PR DESCRIPTION
O objetivo deste PR é adicionar uma nova versão do modelo do segundo estágio do pipeline de processamento das provas.

A principal diferença deste modelo para o anterior é a capacidade de detectar as "unselected_ball", tanto das questões quanto dos CPFs.

Exemplo:
![image](https://github.com/einsteinfloripa/leitor-simulados/assets/51864511/9ac4eba0-bfd1-4297-9390-46418993ef89)
